### PR TITLE
Multi-Post YAML type

### DIFF
--- a/posts.example/example-post-multi.yaml
+++ b/posts.example/example-post-multi.yaml
@@ -1,0 +1,18 @@
+type: posts
+topic: example-topic
+trigger:
+  type: flag
+  tag: flag02
+posts:
+  - api:
+      user: john-doe
+      key: 87075d4b01b6572bb83267e201a2dc9e20ca5be2c184eb59eb2578318d175f1e
+
+    body: |-
+      This is posted as John Doe and will be posted before the post below
+  - api:
+      user: jane-doe
+      key: 87075d4b01b6572bb83267e201a2dc9e20ca5be2c184eb59eb2578318d175f1e
+
+    body: |-
+      This is posted after the above post, by Jane Doe


### PR DESCRIPTION
We've had some requirements to be able to post multiple replies on a Discourse topic in order using the same trigger. The problem we've had in the past is that having multiple post files does not guarantee the order if they all have the same score/flag trigger.

This new "posts" type adds a post array in the YAML structure that can define a body and a specifc API user for each sub posts to create.

cc @stgraber 