### PR TITLE
Add feature to support team specific template variables in YAML

### DIFF
--- a/posts.example/example-topic-variables.yaml
+++ b/posts.example/example-topic-variables.yaml
@@ -1,0 +1,15 @@
+type: topic
+
+title: New challenge !
+body: |-
+  Challenge with a team specific variable : %{my_var}
+
+variables:
+  my_var:
+    0: variable for team 000
+    1: variable for team 001
+    2: variable for team 002
+    3: variable for team 003
+    4: variable for team 004
+    # and so on...
+


### PR DESCRIPTION
This PR allows our yaml files to contain template variables that change value depending on the team. We already support `%{team_name}` and `%{team_score}`. Now this supports any value that matches `%{my_variable}` to be replaces by the content the of the `variables` map in the YAML file.

This means a value needs to be provided by the YAML file for every team, otherwise the resulting replacement will replace with an empty string.

I wonder if we want to make the `processEntry` method return an error in this so that we don't even process the topic/post at all?

Let me know what you think!